### PR TITLE
Use dontrun for test examples vs donttest

### DIFF
--- a/R/mvgam.R
+++ b/R/mvgam.R
@@ -164,7 +164,7 @@
 #'for other functions in the package
 #'
 #'@examples
-#'\donttest{
+#'\dontrun{
 #'# Simulate a collection of three time series that have shared seasonal dynamics
 # # and independent random walk trends, with a Poisson observation process
 #'dat <- sim_mvgam(T = 80, n_series = 3, prop_missing = 0.1,

--- a/man/get_mvgam_priors.Rd
+++ b/man/get_mvgam_priors.Rd
@@ -100,7 +100,6 @@ mod_default <- mvgam(y ~ s(series, bs = 're') +
               family = 'nb',
               data = dat$data_train,
               trend_model = 'AR2',
-              priors = test_priors,
               run_model = FALSE)
 
 # Inspect the model file with default mvgam priors

--- a/man/mvgam.Rd
+++ b/man/mvgam.Rd
@@ -225,7 +225,7 @@ of more response distributions, plans to handle zero-inflation, and plans to inc
 variety of trend models. Users are strongly encouraged to opt for \code{Stan} over \code{JAGS} in any proceeding workflows
 }
 \examples{
-\donttest{
+\dontrun{
 # Simulate a collection of three time series that have shared seasonal dynamics
 dat <- sim_mvgam(T = 80, n_series = 3, prop_missing = 0.1,
                 trend_rel = 0.6)


### PR DESCRIPTION
dontrun avoids running the tests during package check
update man, remove old parameters`priors = test_priors`.