### PR TITLE
VignetteBuilder field but no prebuilt vignette index

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,8 +2,12 @@
 ^\.Rproj\.user$
 ^LICENSE\.md$
 ^doc$
-^Meta$
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
 ^\.github$
+^README.Rmd
+^index.Rmd
+^index.md
+^manuscript_analysis
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.Rproj.user
 .Rhistory
 .RData
 .Ruserdata
@@ -6,3 +5,4 @@ NEON_manuscript/Results/
 manuscript_analysis
 doc
 Meta
+*.Rproj*


### PR DESCRIPTION
Meta/vignettes.rds is automatically generated by devtools do not list it in .Rbuildignore


fixes: #11