### PR TITLE
test namespace

### DIFF
--- a/tests/testthat/test-mvgam-methods.R
+++ b/tests/testthat/test-mvgam-methods.R
@@ -238,19 +238,19 @@ test_that("logLik has reasonable ouputs", {
 test_that("predict has reasonable outputs", {
   newdat1 <- data.frame(series = 'series_1')
   expect_error(
-    predict(mvgam_example1, newdata = newdat1),
+    predict(mvgam:::mvgam_example1, newdata = newdat1),
     "the following required variables are missing from newdata:\n season"
   )
 
   newdat2 <- data.frame(series = factor('series_1'), time = 1)
   expect_error(
-    predict(mvgam_example1, newdata = newdat2),
+    predict(mvgam:::mvgam_example1, newdata = newdat2),
     "the following required variables are missing from newdata:\n season"
   )
 
   newdat3 <- list(series = factor('series_1'), time = 1)
   expect_error(
-    predict(mvgam_example4, newdata = newdat3),
+    predict(mvgam:::mvgam_example4, newdata = newdat3),
     "the following required variables are missing from newdata:\n season"
   )
 


### PR DESCRIPTION
FYI, I submitted a new version of `marginaleffects` to CRAN and was told that it broke tests in `mvgam` (a revdep).

I am unable to find an error specifically related to the changes in this version. However, I did have to add an explicit namespace to a few lines in this test file in order to run the suite.

Let me know if you run into issues with the new `marginaleffects` and I can help debug as necessary.